### PR TITLE
Ignore `out/` directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 composer.lock
 composer.phar
 vendor/
-
+out/
 
 .DS_Store
 README.md.temp


### PR DESCRIPTION
The `./vendor/bin/phel compile` generate the compile code inside the `out/` directory.
I think it would be interesting to ignore it.